### PR TITLE
Do not sort completion items

### DIFF
--- a/plugin/ncm2_vim_lsp.vim
+++ b/plugin/ncm2_vim_lsp.vim
@@ -27,6 +27,7 @@ func! s:register_source() abort
             \ 'name': source_name,
             \ 'priority': 9,
             \ 'mark': svr_name,
+            \ 'sorter': 'none',
             \ 'on_complete': function('s:on_complete', [svr_name]),
             \ 'complete_pattern': patterns,
             \ }


### PR DESCRIPTION
Fixes #7 

Vim-lsp implements the `preselect` part of the LSP specification by putting the preselected item first in the list; ncm2's default `abbrvfuzzy` breaks this functionality.

This is a stopgap fix until sorting is sorted out more completely based on the `sortText` part of the specification (and when it's decided whether sorting is the language client's or the autocompleter's responsibility).