### PR TITLE
Pass server name to get_vim_completion_item

### DIFF
--- a/plugin/ncm2_vim_lsp.vim
+++ b/plugin/ncm2_vim_lsp.vim
@@ -94,7 +94,7 @@ func! s:on_completion_result(server_name, ctx, data) abort
 
     " fill user_data
     let lspitems = deepcopy(items)
-    call map(items, 'lsp#omni#get_vim_completion_item(v:val)')
+    call map(items, 'lsp#omni#get_vim_completion_item(v:val, a:server_name)')
     let i = 0
     while l:i < len(items)
         let ud = {}


### PR DESCRIPTION
Adapts to change in vim-lsp: `lsp#omni#get_vim_completion_item` now takes the (optional) server name to allow for configurable custom mappings from kind id to text per server; see https://github.com/prabirshrestha/vim-lsp/pull/524.

This change is needed to also show the custom names on autocomplete.