### PR TITLE
Fix completions for recent version of vim-lsp

### DIFF
--- a/plugin/ncm2_vim_lsp.vim
+++ b/plugin/ncm2_vim_lsp.vim
@@ -82,29 +82,14 @@ func! s:on_completion_result(server_name, ctx, data) abort
         return
     endif
 
-    let result = a:data['response']['result']
+    let options = {
+    	\ 'server': lsp#get_server_info(a:server_name),
+    	\ 'response': a:data['response'],
+    	\ 'position': lsp#get_position()
+		\ }
+    let result = lsp#omni#get_vim_completion_items(options)
 
-    if type(result) == type([])
-        let items = result
-        let incomplete = 0
-    else
-        let items = result['items']
-        let incomplete = result['isIncomplete']
-    endif
-
-    " fill user_data
-    let lspitems = deepcopy(items)
-    call map(items, 'lsp#omni#get_vim_completion_item(v:val, a:server_name)')
-    let i = 0
-    while l:i < len(items)
-        let ud = {}
-        let ud['lspitem'] = lspitems[i]
-        let ud['vim_lsp'] = {'server_name': a:server_name}
-        let items[i].user_data = ud
-        let i += 1
-    endwhile
-
-    call ncm2#complete(a:ctx, a:ctx.startccol, items, incomplete)
+    call ncm2#complete(a:ctx, a:ctx.startccol, result['items'], result['incomplete'])
 endfunc
 
 func! ncm2_vim_lsp#completionitem_resolve(user_data, item) abort


### PR DESCRIPTION
Fixes #12

The recent commits for vim-lsp have deprecated `lsp#omni#get_vim_completion_item` in favour of `lsp#omni#get_vim_completion_items`, breaking all of LSP completion whichrelied on the old function. This patch aims for port the source to the new API.

The new code just passes on the results from `lsp#omni#get_vim_completion_items`, it does not process the data in any way. Please let me know if I missed anything. There is practically no documentation by vim-lsp, so this is me just poking around in the dark.